### PR TITLE
Detect and remove \r with bash and sed

### DIFF
--- a/pwned_pass.sh
+++ b/pwned_pass.sh
@@ -33,8 +33,8 @@ echo 'Looking up your password...'
 raw_count=$(curl -s "https://api.pwnedpasswords.com/range/$hash_prefix" | grep -i "$hash_suffix" | cut -d':' -f2 || true)
 
 # Remove carriage return
-if [ ${raw_count:(-1):1} == $'\r' ]; then
-	count=${raw_count::-1}
+if [ ${raw_count: (-1) : 1} == $'\r' ]; then
+	count=${raw_count: : -1}
 else
 	count=$raw_count
 fi

--- a/pwned_pass.sh
+++ b/pwned_pass.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 
 set -eo pipefail
 
@@ -30,7 +30,7 @@ echo "Hash suffix: $hash_suffix"
 echo
 echo 'Looking up your password...'
 
-raw_count=$(curl -s "https://api.pwnedpasswords.com/range/$hash_prefix" | grep -i "$hash_suffix" | cut -d':' -f2 || true)
+raw_count=$(curl -s "https://api.pwnedpasswords.com/range/$hash_prefix" | grep -i "$hash_suffix" | cut -d':' -f2 || echo 0)
 
 # Remove carriage return
 if [ ${raw_count: (-1) : 1} == $'\r' ]; then

--- a/pwned_pass.sh
+++ b/pwned_pass.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash 
 
 set -eo pipefail
 
@@ -31,8 +31,13 @@ echo
 echo 'Looking up your password...'
 
 raw_count=$(curl -s "https://api.pwnedpasswords.com/range/$hash_prefix" | grep -i "$hash_suffix" | cut -d':' -f2 || true)
-# printf doesn't like some of the characters in the response text, but Python obliges
-count=$(python -c "print(int($raw_count))")
+
+# Remove carriage return
+if [ ${raw_count:(-1):1} == $'\r' ]; then
+	count=${raw_count::-1}
+else
+	count=$raw_count
+fi
 
 printf "Your password appears in the Pwned Passwords database %u time(s).\\n" "$count"
 


### PR DESCRIPTION
we don't need to use python for detect and
stripping the carriage return at the end
of the returned string